### PR TITLE
feat: add site pages and update navigation

### DIFF
--- a/src/imagetools.d.ts
+++ b/src/imagetools.d.ts
@@ -1,0 +1,4 @@
+declare module '*&as=srcset' {
+	const srcset: string;
+	export default srcset;
+}

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -2,6 +2,11 @@
 	import portrait from '$lib/assets/img/portrait.jpg?format=webp&w=320;480;640;720;900;1080;1200;1440;1600;1920;2560;3840&fit=inside&rotate=270&withoutEnlargement&as=srcset';
 </script>
 
+<svelte:head>
+	<title>Home | mia.cx</title>
+	<meta name="description" content="The personal website and portfolio of Mia Riezebos." />
+</svelte:head>
+
 <!-- Coming Soon -->
 <section id="coming-soon" class="justify-self-center">
 	<div

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 	import portrait from '$lib/assets/img/portrait.jpg?format=webp&w=320;480;640;720;900;1080;1200;1440;1600;1920;2560;3840&fit=inside&rotate=270&withoutEnlargement&as=srcset';
-
-	console.debug('portrait', portrait);
 </script>
 
 <!-- Coming Soon -->
@@ -22,15 +20,15 @@
 			<br />
 			<p>
 				If you have an inquiry or would like to get in touch, please email Mia Riezebos at
-				<a class="group" href="mailto:contact@mia.cx">
-					contact@mia.cx
+				<a class="group" href="mailto:hello@mia.cx">
+					hello@mia.cx
 					<iconify-icon
 						icon="lucide:arrow-up-right"
 						class="opacity-50 group-hover:opacity-100 -ml-1"
 					/>
 				</a>, or send a WhatsApp message to
 				<a class="group" href="https://wa.me/message/K6JIESWVSFVBN1">
-					‪+31 31 72 250 05‬
+					+31 31 72 250 05
 					<iconify-icon
 						icon="lucide:arrow-up-right"
 						class="opacity-50 group-hover:opacity-100 -ml-1"

--- a/src/routes/(app)/Footer.svelte
+++ b/src/routes/(app)/Footer.svelte
@@ -1,3 +1,9 @@
+<script lang="ts">
+	const currentYear = new Date().getFullYear();
+	const workPhone = '+31 31 72 250 05';
+	const workPhoneHref = `tel:${workPhone.replace(/\s/g, '')}`;
+</script>
+
 <footer class="py-8">
 	<div class="container grid grid-cols-1 md:grid-cols-4 items-start gap-4">
 		<section class="md:col-span-2 h-full flex flex-col justify-between">
@@ -20,6 +26,7 @@
 					<li>
 						<a
 							class="flex items-center hover:text-linkedin"
+							aria-label="LinkedIn"
 							target="_blank"
 							href="https://linkedin.com/company/miacx"
 						>
@@ -32,6 +39,7 @@
 					<li>
 						<a
 							class="flex items-center"
+							aria-label="GitHub"
 							target="_blank"
 							href="https://github.com/mia-cx"
 						>
@@ -44,6 +52,7 @@
 					<li>
 						<a
 							class="flex items-center hover:text-twitter"
+							aria-label="Twitter"
 							target="_blank"
 							href="https://twitter.com/patchstep"
 						>
@@ -140,8 +149,8 @@
 						class="opacity-50 group-hover:opacity-100"
 					/>
 				</a><br />
-				<a class="group" href="tel:+31640362794">
-					+31 6 40 36 27 94
+				<a class="group" href={workPhoneHref}>
+					{workPhone}
 					<iconify-icon
 						icon="lucide:arrow-up-right"
 						class="opacity-50 group-hover:opacity-100"
@@ -152,7 +161,7 @@
 		<!-- credit -->
 
 		<div class="flex max-sm:flex-col md:col-span-4 gap-x-4 gap-y-2">
-			<span>© 2023 mia.cx</span>
+			<span>© {currentYear} mia.cx</span>
 		</div>
 	</div>
 </footer>

--- a/src/routes/(app)/Footer.svelte
+++ b/src/routes/(app)/Footer.svelte
@@ -60,11 +60,11 @@
 						<a
 							class="group flex items-center gap-2"
 							target="_blank"
-							href="mailto:contact@mia.cx"
+							href="mailto:hello@mia.cx"
 						>
 							<iconify-icon class="text-6xl md:text-2xl" icon="lucide:mail" />
 							<span class="text-base hidden lg:inline">
-								contact@mia.cx
+								hello@mia.cx
 								<iconify-icon
 									icon="lucide:arrow-up-right"
 									class="opacity-50 group-hover:opacity-100"
@@ -97,8 +97,8 @@
 					</a>
 				</li>
 				<li>
-					<a class="group inline-flex items-center gap-2 hover:gap-3" href="/about">
-						About
+					<a class="group inline-flex items-center gap-2 hover:gap-3" href="/blog">
+						Blog
 						<iconify-icon
 							icon="lucide:arrow-right"
 							class="translate-y-[10%] opacity-50 group-hover:opacity-100"
@@ -114,6 +114,18 @@
 						/>
 					</a>
 				</li>
+				<li>
+					<a
+						class="group inline-flex items-center gap-2 hover:gap-3"
+						href="https://ffm.bio/patch"
+					>
+						Music
+						<iconify-icon
+							icon="lucide:arrow-up-right"
+							class="translate-y-[10%] opacity-50 group-hover:opacity-100"
+						/>
+					</a>
+				</li>
 			</ul>
 		</section>
 
@@ -121,8 +133,8 @@
 			<h2>Support</h2>
 			<p>
 				mia.cx<br />
-				<a class="group" href="mailto:contact@mia.cx">
-					contact@mia.cx
+				<a class="group" href="mailto:hello@mia.cx">
+					hello@mia.cx
 					<iconify-icon
 						icon="lucide:arrow-up-right"
 						class="opacity-50 group-hover:opacity-100"

--- a/src/routes/(app)/Header.svelte
+++ b/src/routes/(app)/Header.svelte
@@ -14,14 +14,14 @@
 <header
 	class="z-10 sticky top-0 flex items-center h-[var(--header-height)] hover:[&_a]:text-primary font-bold bg-neutral"
 >
-	<div class="container flex gap-8">
+	<div class="container flex items-center gap-4 sm:gap-8">
 		<!-- TODO Hamburger -->
 		<span class="flex-1"><a href="/" class="reset">mia.cx</a></span>
-		<nav class="flex gap-8">
+		<nav class="flex gap-3 text-sm sm:gap-8 sm:text-base">
 			<a class="reset" href="/projects">Projects</a>
-			<a class="reset" href="/about">About</a>
+			<a class="reset" href="/blog">Blog</a>
 			<a class="reset" href="/contact">Contact</a>
-			<a class="reset" href="https://patchstep.com">Patch</a>
+			<a class="reset" href="https://ffm.bio/patch">Music</a>
 		</nav>
 	</div>
 </header>

--- a/src/routes/(app)/about/+page.ts
+++ b/src/routes/(app)/about/+page.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export function load() {
+	throw redirect(308, '/');
+}

--- a/src/routes/(app)/blog/+page.svelte
+++ b/src/routes/(app)/blog/+page.svelte
@@ -1,0 +1,6 @@
+<section class="container py-8 md:py-16">
+	<div class="max-w-3xl">
+		<h1>Blog</h1>
+		<p>The blog is under construction. Check back soon for updates.</p>
+	</div>
+</section>

--- a/src/routes/(app)/blog/+page.svelte
+++ b/src/routes/(app)/blog/+page.svelte
@@ -1,3 +1,8 @@
+<svelte:head>
+	<title>Blog | mia.cx</title>
+	<meta name="description" content="The mia.cx blog is currently under construction." />
+</svelte:head>
+
 <section class="container py-8 md:py-16">
 	<div class="max-w-3xl">
 		<h1>Blog</h1>

--- a/src/routes/(app)/contact/+page.svelte
+++ b/src/routes/(app)/contact/+page.svelte
@@ -1,0 +1,45 @@
+<section class="container py-8 md:py-16">
+	<div class="max-w-3xl">
+		<h1>Contact</h1>
+		<p>For inquiries or to get in touch, contact Mia directly.</p>
+
+		<ul class="mt-8 space-y-4">
+			<li>
+				Email:
+				<a class="group inline-flex items-center gap-0.5" href="mailto:hello@mia.cx">
+					hello@mia.cx
+					<iconify-icon
+						icon="lucide:arrow-up-right"
+						class="opacity-50 group-hover:opacity-100"
+					/>
+				</a>
+			</li>
+			<li>
+				WhatsApp:
+				<a
+					class="group inline-flex items-center gap-0.5"
+					href="https://wa.me/message/K6JIESWVSFVBN1"
+				>
+					+31 31 72 250 05
+					<iconify-icon
+						icon="lucide:arrow-up-right"
+						class="opacity-50 group-hover:opacity-100"
+					/>
+				</a>
+			</li>
+			<li>
+				Discord:
+				<a
+					class="group inline-flex items-center gap-0.5"
+					href="https://discord.com/users/209048057441026049"
+				>
+					@patchstep
+					<iconify-icon
+						icon="lucide:arrow-up-right"
+						class="opacity-50 group-hover:opacity-100"
+					/>
+				</a>
+			</li>
+		</ul>
+	</div>
+</section>

--- a/src/routes/(app)/contact/+page.svelte
+++ b/src/routes/(app)/contact/+page.svelte
@@ -1,3 +1,8 @@
+<svelte:head>
+	<title>Contact | mia.cx</title>
+	<meta name="description" content="Contact details for Mia Riezebos." />
+</svelte:head>
+
 <section class="container py-8 md:py-16">
 	<div class="max-w-3xl">
 		<h1>Contact</h1>

--- a/src/routes/(app)/projects/+page.svelte
+++ b/src/routes/(app)/projects/+page.svelte
@@ -51,6 +51,11 @@
 	];
 </script>
 
+<svelte:head>
+	<title>Projects | mia.cx</title>
+	<meta name="description" content="A selection of public projects and experiments by Mia Riezebos." />
+</svelte:head>
+
 <section class="container py-8 md:py-16">
 	<div class="max-w-4xl">
 		<h1>Projects</h1>

--- a/src/routes/(app)/projects/+page.svelte
+++ b/src/routes/(app)/projects/+page.svelte
@@ -16,29 +16,29 @@
 		},
 		{
 			owner: 'mia-cx',
-			name: 'ditherette',
-			description: 'An in-browser image dithering and colour-conversion tool.',
+			name: 'maal',
+			description:
+				'A flexible meal-planning and household logistics app built around floating schedules, recipe imports, grocery demand, and capacity-aware planning.',
 			language: 'TypeScript'
 		},
 		{
 			owner: 'mia-cx',
-			name: 'rule-composer',
+			name: 'honeybot',
 			description:
-				'A command-line tool for writing AI coding-agent rules once and generating variants for multiple supported tools.',
-			language: 'TypeScript'
-		},
-		{
-			owner: 'mia-cx',
-			name: 'drizzle-query-factory',
-			description:
-				'A declarative, composable query-parameter parser that produces typed filtering, sorting, and pagination for Drizzle ORM.',
+				'A self-hosted Discord moderation bot that catches scam and spam raids using honeypots, repeat detection, evidence matching, AI classifiers, and moderator review.',
 			language: 'TypeScript'
 		},
 		{
 			owner: 'mia-riezebos',
-			name: 'lossless-url-compressor',
+			name: 'patch',
 			description:
-				'A work-in-progress specification and TypeScript proof of concept for deterministic, stateless, lossless URL compression.',
+				'A Discord harness for a locally hosted LLM designed as a conversational server character with her own voice, taste, boundaries, and timing.',
+			language: 'TypeScript'
+		},
+		{
+			owner: 'mia-cx',
+			name: 'ditherette',
+			description: 'An in-browser image dithering and colour-conversion tool.',
 			language: 'TypeScript'
 		},
 		{

--- a/src/routes/(app)/projects/+page.svelte
+++ b/src/routes/(app)/projects/+page.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	type Project = {
+		owner: string;
+		name: string;
+		description: string;
+		language: string;
+	};
+
+	const projects: Project[] = [
+		{
+			owner: 'vesta-cx',
+			name: 'vesta',
+			description:
+				'An all-in-one platform for independent musicians, small labels, and creative publishers to manage their catalog, build their brand, and reach their audience.',
+			language: 'TypeScript'
+		},
+		{
+			owner: 'mia-cx',
+			name: 'ditherette',
+			description: 'An in-browser image dithering and colour-conversion tool.',
+			language: 'TypeScript'
+		},
+		{
+			owner: 'mia-cx',
+			name: 'rule-composer',
+			description:
+				'A command-line tool for writing AI coding-agent rules once and generating variants for multiple supported tools.',
+			language: 'TypeScript'
+		},
+		{
+			owner: 'mia-cx',
+			name: 'drizzle-query-factory',
+			description:
+				'A declarative, composable query-parameter parser that produces typed filtering, sorting, and pagination for Drizzle ORM.',
+			language: 'TypeScript'
+		},
+		{
+			owner: 'mia-riezebos',
+			name: 'lossless-url-compressor',
+			description:
+				'A work-in-progress specification and TypeScript proof of concept for deterministic, stateless, lossless URL compression.',
+			language: 'TypeScript'
+		},
+		{
+			owner: 'mia-riezebos',
+			name: 'novel-audio-codec-experiment',
+			description:
+				'A dependency-free Rust prototype exploring a perceptually native audio codec with transform coding and psychoacoustic shaping.',
+			language: 'Rust'
+		}
+	];
+</script>
+
+<section class="container py-8 md:py-16">
+	<div class="max-w-4xl">
+		<h1>Projects</h1>
+		<p>A selection of public projects and experiments.</p>
+
+		<ul class="mt-8 grid grid-cols-1 md:grid-cols-2 gap-4">
+			{#each projects as project}
+				<li class="border border-current/20 rounded-xl p-6">
+					<a
+						class="group inline-flex items-center gap-1 font-bold"
+						href={`https://github.com/${project.owner}/${project.name}`}
+						target="_blank"
+						rel="noreferrer"
+					>
+						{project.owner}/{project.name}
+						<iconify-icon
+							icon="lucide:arrow-up-right"
+							class="opacity-50 group-hover:opacity-100"
+						/>
+					</a>
+					<p class="mt-3">{project.description}</p>
+					<p class="mt-4 text-sm opacity-60">{project.language}</p>
+				</li>
+			{/each}
+		</ul>
+	</div>
+</section>

--- a/src/routes/(app)/projects/+page.svelte
+++ b/src/routes/(app)/projects/+page.svelte
@@ -61,9 +61,9 @@
 		<h1>Projects</h1>
 		<p>A selection of public projects and experiments.</p>
 
-		<ul class="mt-8 grid grid-cols-1 md:grid-cols-2 gap-4">
+		<ul class="mt-8 divide-y divide-current/20" data-testid="project-list">
 			{#each projects as project}
-				<li class="border border-current/20 rounded-xl p-6">
+				<li class="py-6 first:pt-0 last:pb-0">
 					<a
 						class="group inline-flex items-center gap-1 font-bold"
 						href={`https://github.com/${project.owner}/${project.name}`}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -13,36 +13,20 @@
 	<meta name="description" content={description} />
 </svelte:head>
 
-<section class="container py-10 md:py-20">
-	<div class="grid items-center gap-8 md:grid-cols-[minmax(0,1fr)_minmax(16rem,0.7fr)] md:gap-12">
-		<div>
-			<p class="font-bold uppercase tracking-[0.2em] text-primary">Error {$page.status}</p>
-			<h1 class="mt-2">{title}</h1>
-			<p class="mt-4 max-w-xl text-lg">{description}</p>
+<section class="container py-8 md:py-16">
+	<div class="max-w-3xl">
+		<h1>{$page.status}: {title}</h1>
+		<p>{description}</p>
 
-			<div class="mt-8 flex flex-col gap-3 sm:flex-row">
-				<a
-					class="reset group inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl bg-primary px-5 py-3 font-bold text-neutral"
-					href="/"
-				>
-					Go home
-					<iconify-icon icon="lucide:arrow-right" class="group-hover:translate-x-0.5" />
-				</a>
-				<a
-					class="reset group inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl border border-current/20 px-5 py-3 font-bold hover:border-current/50"
-					href="/contact"
-				>
-					Contact Mia
-					<iconify-icon icon="lucide:arrow-right" class="group-hover:translate-x-0.5" />
-				</a>
-			</div>
-		</div>
-
-		<p
-			class="hidden select-none text-right text-[clamp(7rem,24vw,12rem)] font-bold leading-none text-primary opacity-20 md:block"
-			aria-hidden="true"
-		>
-			{$page.status}
-		</p>
+		<nav class="mt-8 flex flex-col items-start gap-2" aria-label="Error recovery">
+			<a class="group inline-flex items-center gap-1 font-bold" href="/">
+				Go home
+				<iconify-icon icon="lucide:arrow-right" class="opacity-50 group-hover:opacity-100" />
+			</a>
+			<a class="group inline-flex items-center gap-1 font-bold" href="/contact">
+				Contact Mia
+				<iconify-icon icon="lucide:arrow-right" class="opacity-50 group-hover:opacity-100" />
+			</a>
+		</nav>
 	</div>
 </section>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+
+	$: isNotFound = $page.status === 404;
+	$: title = isNotFound ? 'Page not found' : 'Something went wrong';
+	$: description = isNotFound
+		? 'The page you were looking for does not exist or may have moved.'
+		: 'The site ran into an unexpected problem. Please try again in a moment.';
+</script>
+
+<svelte:head>
+	<title>{$page.status} — {title} | mia.cx</title>
+	<meta name="description" content={description} />
+</svelte:head>
+
+<section class="container py-10 md:py-20">
+	<div class="grid items-center gap-8 md:grid-cols-[minmax(0,1fr)_minmax(16rem,0.7fr)] md:gap-12">
+		<div>
+			<p class="font-bold uppercase tracking-[0.2em] text-primary">Error {$page.status}</p>
+			<h1 class="mt-2">{title}</h1>
+			<p class="mt-4 max-w-xl text-lg">{description}</p>
+
+			<div class="mt-8 flex flex-col gap-3 sm:flex-row">
+				<a
+					class="reset group inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl bg-primary px-5 py-3 font-bold text-neutral"
+					href="/"
+				>
+					Go home
+					<iconify-icon icon="lucide:arrow-right" class="group-hover:translate-x-0.5" />
+				</a>
+				<a
+					class="reset group inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl border border-current/20 px-5 py-3 font-bold hover:border-current/50"
+					href="/contact"
+				>
+					Contact Mia
+					<iconify-icon icon="lucide:arrow-right" class="group-hover:translate-x-0.5" />
+				</a>
+			</div>
+		</div>
+
+		<p
+			class="hidden select-none text-right text-[clamp(7rem,24vw,12rem)] font-bold leading-none text-primary opacity-20 md:block"
+			aria-hidden="true"
+		>
+			{$page.status}
+		</p>
+	</div>
+</section>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
 	import 'iconify-icon';
-	import Header from './Header.svelte';
+	import Header from './(app)/Header.svelte';
 	import '$lib/styles/app.scss';
-	import Footer from './Footer.svelte';
+	import Footer from './(app)/Footer.svelte';
 </script>
 
 <!-- Header : fixed -->
 <Header />
 <main class="relative flex-1 flex flex-col justify-center">
-
 	<slot />
 	<!-- Footer : sticky -->
 </main>

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -62,3 +62,14 @@ test('contact page renders the existing contact methods', async ({ page }) => {
 		'@patchstep'
 	);
 });
+
+test('unknown routes use the shared layout and custom error page', async ({ page }) => {
+	const response = await page.goto('/this-page-does-not-exist');
+
+	expect(response?.status()).toBe(404);
+	await expect(page.getByRole('banner')).toBeVisible();
+	await expect(page.getByRole('main').getByRole('heading', { name: 'Page not found' })).toBeVisible();
+	await expect(page.getByRole('main').getByText('404', { exact: true })).toBeVisible();
+	await expect(page.getByRole('main').getByRole('link', { name: 'Go home' })).toHaveAttribute('href', '/');
+	await expect(page.getByRole('contentinfo')).toBeVisible();
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -63,13 +63,46 @@ test('contact page renders the existing contact methods', async ({ page }) => {
 	);
 });
 
+test('about redirects to the home page', async ({ page }) => {
+	await page.goto('/about');
+	await expect(page).toHaveURL('/');
+});
+
+test('pages expose concise titles and descriptions', async ({ page }) => {
+	const pages = [
+		['/', 'Home | mia.cx'],
+		['/projects', 'Projects | mia.cx'],
+		['/blog', 'Blog | mia.cx'],
+		['/contact', 'Contact | mia.cx']
+	];
+
+	for (const [route, title] of pages) {
+		await page.goto(route);
+		await expect(page).toHaveTitle(title);
+		await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', /\S+/);
+	}
+});
+
+test('footer uses the work number and accessible social labels', async ({ page }) => {
+	await page.goto('/');
+	const footer = page.getByRole('contentinfo');
+	const workPhone = '+31 31 72 250 05';
+	const workPhoneHref = `tel:${workPhone.replace(/\s/g, '')}`;
+
+	await expect(footer.locator(`a[href="${workPhoneHref}"]`)).toContainText(workPhone);
+	await expect(footer.getByText('+31 6 40 36 27 94')).toHaveCount(0);
+	await expect(footer.getByText(`© ${new Date().getFullYear()} mia.cx`)).toBeVisible();
+	await expect(footer.getByRole('link', { name: 'LinkedIn' })).toBeVisible();
+	await expect(footer.getByRole('link', { name: 'GitHub' })).toBeVisible();
+	await expect(footer.getByRole('link', { name: 'Twitter' })).toBeVisible();
+});
+
 test('unknown routes use the shared layout and custom error page', async ({ page }) => {
 	const response = await page.goto('/this-page-does-not-exist');
 
 	expect(response?.status()).toBe(404);
 	await expect(page.getByRole('banner')).toBeVisible();
-	await expect(page.getByRole('main').getByRole('heading', { name: 'Page not found' })).toBeVisible();
-	await expect(page.getByRole('main').getByText('404', { exact: true })).toBeVisible();
+	await expect(page.getByRole('main').getByRole('heading', { name: '404: Page not found' })).toBeVisible();
 	await expect(page.getByRole('main').getByRole('link', { name: 'Go home' })).toHaveAttribute('href', '/');
 	await expect(page.getByRole('contentinfo')).toBeVisible();
 });

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -44,6 +44,16 @@ test('projects page renders the handpicked public repositories', async ({ page }
 	for (const href of projects) {
 		await expect(page.locator(`a[href="${href}"]`)).toBeVisible();
 	}
+
+	const projectList = page.getByTestId('project-list');
+	await expect(projectList).not.toHaveClass(/grid|rounded/);
+	await expect(projectList.locator('li').first()).not.toHaveClass(/rounded/);
+	expect(
+		await projectList
+			.locator('li')
+			.nth(1)
+			.evaluate((item) => getComputedStyle(item).borderTopWidth)
+	).not.toBe('0px');
 });
 
 test('blog page renders an under-construction placeholder', async ({ page }) => {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -2,10 +2,10 @@ import { expect, test } from '@playwright/test';
 
 const projects = [
 	'https://github.com/vesta-cx/vesta',
+	'https://github.com/mia-cx/maal',
+	'https://github.com/mia-cx/honeybot',
+	'https://github.com/mia-riezebos/patch',
 	'https://github.com/mia-cx/ditherette',
-	'https://github.com/mia-cx/rule-composer',
-	'https://github.com/mia-cx/drizzle-query-factory',
-	'https://github.com/mia-riezebos/lossless-url-compressor',
 	'https://github.com/mia-riezebos/novel-audio-codec-experiment'
 ];
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,6 +1,64 @@
 import { expect, test } from '@playwright/test';
 
-test('index page has expected h1', async ({ page }) => {
+const projects = [
+	'https://github.com/vesta-cx/vesta',
+	'https://github.com/mia-cx/ditherette',
+	'https://github.com/mia-cx/rule-composer',
+	'https://github.com/mia-cx/drizzle-query-factory',
+	'https://github.com/mia-riezebos/lossless-url-compressor',
+	'https://github.com/mia-riezebos/novel-audio-codec-experiment'
+];
+
+test('shared header exposes the requested navigation', async ({ page }) => {
 	await page.goto('/');
-	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
+
+	const header = page.getByRole('banner');
+	await expect(header.getByRole('link', { name: 'Projects' })).toHaveAttribute('href', '/projects');
+	await expect(header.getByRole('link', { name: 'Blog' })).toHaveAttribute('href', '/blog');
+	await expect(header.getByRole('link', { name: 'Contact' })).toHaveAttribute('href', '/contact');
+	await expect(header.getByRole('link', { name: 'Music' })).toHaveAttribute('href', 'https://ffm.bio/patch');
+	await expect(header.getByRole('link', { name: 'About' })).toHaveCount(0);
+
+	const footer = page.getByRole('contentinfo');
+	await expect(footer.getByRole('link', { name: 'Blog' })).toHaveAttribute('href', '/blog');
+	await expect(footer.getByRole('link', { name: 'Music' })).toHaveAttribute('href', 'https://ffm.bio/patch');
+	await expect(footer.locator('a[href="mailto:hello@mia.cx"]')).toHaveCount(2);
+	await expect(page.getByRole('link', { name: 'About' })).toHaveCount(0);
+});
+
+test('shared header fits a mobile viewport', async ({ page }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.goto('/');
+
+	await expect(page.getByRole('banner').getByRole('link', { name: 'Music' })).toBeInViewport();
+	const hasHorizontalOverflow = await page.evaluate(
+		() => document.documentElement.scrollWidth > document.documentElement.clientWidth
+	);
+	expect(hasHorizontalOverflow).toBe(false);
+});
+
+test('projects page renders the handpicked public repositories', async ({ page }) => {
+	await page.goto('/projects');
+	await expect(page.getByRole('heading', { level: 1, name: 'Projects' })).toBeVisible();
+
+	for (const href of projects) {
+		await expect(page.locator(`a[href="${href}"]`)).toBeVisible();
+	}
+});
+
+test('blog page renders an under-construction placeholder', async ({ page }) => {
+	await page.goto('/blog');
+	await expect(page.getByRole('heading', { level: 1, name: 'Blog' })).toBeVisible();
+	await expect(page.getByText(/under construction/i)).toBeVisible();
+});
+
+test('contact page renders the existing contact methods', async ({ page }) => {
+	await page.goto('/contact');
+	const main = page.getByRole('main');
+	await expect(main.getByRole('heading', { level: 1, name: 'Contact' })).toBeVisible();
+	await expect(main.locator('a[href="mailto:hello@mia.cx"]')).toBeVisible();
+	await expect(main.locator('a[href="https://wa.me/message/K6JIESWVSFVBN1"]')).toBeVisible();
+	await expect(main.locator('a[href="https://discord.com/users/209048057441026049"]')).toContainText(
+		'@patchstep'
+	);
 });


### PR DESCRIPTION
## Summary

- add Projects, Contact, and under-construction Blog routes so the shared navigation no longer points to missing pages
- replace About with Blog and Patch with Music, linking Music to https://ffm.bio/patch
- add a handpicked set of mature public projects from `mia-cx`, `mia-riezebos`, and `vesta-cx`
- update contact email links to `hello@mia.cx`
- remove the mobile number and consistently use the work/home number
- add concise page titles and metadata, a dynamic copyright year, and accessible labels for social links
- redirect the retired `/about` route to Home
- add a custom error page using the same plain typography, spacing, monochrome palette, and ordinary links as the rest of the site
- tighten mobile header spacing so all navigation remains visible
- replace the stale Playwright test with route, navigation, content, metadata, footer, redirect, mobile-overflow, and error-layout coverage

## Verification

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] changed-file Prettier and ESLint checks
- [x] `pnpm test` — 9 passed
- [x] `pnpm build`
- [x] `/`, `/projects`, `/blog`, and `/contact` render successfully
- [x] `/about` returns `308` to `/`
- [x] unknown routes return `404` with the custom shared-layout error page
- [x] desktop and 390px mobile visual checks

## Note

The repository-wide `pnpm lint` remains blocked by pre-existing Prettier failures in eight untouched legacy files. This PR does not broaden `.prettierignore` or reformat unrelated files to conceal that baseline issue.
